### PR TITLE
Fix linter config and update timestamp usage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-exclude = venv
+exclude = venv,foundlab-backend

--- a/src/services/scorer.py
+++ b/src/services/scorer.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 from src.models.schemas import WalletData, ScoreResponse
@@ -39,7 +39,7 @@ async def compute_score(data: WalletData) -> ScoreResponse:
                 "score": score,
                 "tier": tier,
                 "flags": flags,
-                "created_at": datetime.utcnow(),
+                "created_at": datetime.now(timezone.utc),
             }
         )
     except Exception:


### PR DESCRIPTION
## Summary
- exclude `foundlab-backend` from flake8 checks
- use timezone-aware timestamp in scoring service

## Testing
- `flake8`
- `coverage run -m pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6845119f75608332a541cf23043f3b61